### PR TITLE
Initialize Node test harness and CSV parsing test

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,13 @@
+{
+  "name": "sexy-slots-v2",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "sexy-slots-v2",
+      "version": "1.0.0",
+      "license": "ISC"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "sexy-slots-v2",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "node --test"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs"
+}

--- a/tests/parseCSV.test.js
+++ b/tests/parseCSV.test.js
@@ -1,0 +1,25 @@
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+// Extract parseCSV function from index.html
+const html = fs.readFileSync(path.join(__dirname, '..', 'index.html'), 'utf8');
+const start = html.indexOf('function parseCSV');
+if (start === -1) throw new Error('parseCSV not found');
+const braceStart = html.indexOf('{', start);
+let i = braceStart + 1;
+let depth = 1;
+while (depth > 0 && i < html.length) {
+  const ch = html[i++];
+  if (ch === '{') depth++;
+  else if (ch === '}') depth--;
+}
+const fnSrc = html.slice(start, i);
+const parseCSV = new Function(fnSrc + '; return parseCSV;')();
+
+test('parseCSV parses simple CSV text', () => {
+  const csv = 'a,b\nc,d';
+  const rows = parseCSV(csv);
+  assert.deepStrictEqual(rows, [{ a: 'c', b: 'd' }]);
+});


### PR DESCRIPTION
## Summary
- set up npm project with a test script using Node's built-in test runner
- add placeholder test verifying `parseCSV` logic via node:test

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689bbbb102088322b3c162976d808f44