### PR TITLE
fix: upload memory fallback in private mode

### DIFF
--- a/index.html
+++ b/index.html
@@ -284,10 +284,15 @@ async function batchImport(files){
   let done=0, ok=0;
   for(const f of files){ if(cancelled) break;
     done++; ptext.textContent=`Importing ${done} of ${files.length}…`; pbar.style.width=Math.round(done/files.length*100)+"%";
-    try{const id=makeId(); await idbPut(id,f);
-      meta[id]={id,name:(f.name||"").replace(/\.[^.]+$/,""),category:"",difficulty:3,hero:3,hiso:3,weight:1,exclude:false,desc:""}; ok++;
+    const id=makeId();
+    try{
+      await storeBlob(id,f); // Use storeBlob to allow memory fallback in private mode (instead of direct idbPut)
+      ok++;
+    }catch(e){console.warn("Import fail",e);}finally{
+      meta[id]={id,name:(f.name||"").replace(/\.[^.]+$/,""),category:"",difficulty:3,hero:3,hiso:3,weight:1,exclude:false,desc:""};
+      meta[id].missing=false;
       await new Promise(r=>requestAnimationFrame(r));
-    }catch(e){console.warn("Import fail",e);}
+    }
   }
   saveMeta(); document.body.removeChild(ov); toast(cancelled?`Cancelled (${ok} saved)`:`Imported ${ok}`); renderSettings(); renderWeights();
 }


### PR DESCRIPTION
## Summary
- use `storeBlob` during batch uploads so memBlobs fallback works in private mode
- always populate `meta` entry after storing to track uploads

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689f659f8f888322a1a1a2cae1bb41aa