### PR TITLE
ci(preview): grant contents:write for gh-pages push

### DIFF
--- a/.github/workflows/pages-preview.yml
+++ b/.github/workflows/pages-preview.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: read
+  contents: write
 
 concurrency:
   group: gh-pages-preview-${{ github.head_ref || github.ref_name }}


### PR DESCRIPTION
## Summary
- allow pages-preview workflow to push by setting `contents: write` permission

## Testing
- `npm test`

Note: ensure the repository has workflow permissions set to **Read and write** and that the `gh-pages` branch is unprotected so the preview deployment can push.

------
https://chatgpt.com/codex/tasks/task_e_68be1a6b7cec832297202b10509c1cbc